### PR TITLE
Use [].concat instead of Array.concat

### DIFF
--- a/common/content/mappings.js
+++ b/common/content/mappings.js
@@ -184,7 +184,7 @@ var MapHive = Class("MapHive", Contexts.Hive, {
      * @param {[Modes.Mode]} modes The modes for which to return mappings.
      */
     iterate: function (modes) {
-        let stacks = Array.concat(modes).map(this.bound.getStack);
+        let stacks = [].concat(modes).map(this.bound.getStack);
         return values(stacks.shift().sort((m1, m2) => String.localeCompare(m1.name, m2.name))
             .filter(map => map.rhs &&
                 stacks.every(stack => stack.some(m => m.rhs && m.rhs === map.rhs && m.name === map.name))));
@@ -201,7 +201,7 @@ var MapHive = Class("MapHive", Contexts.Hive, {
      * @optional
      */
     add: function (modes, keys, description, action, extra={}) {
-        modes = Array.concat(modes);
+        modes = [].concat(modes);
         if (!modes.every(identity))
             throw TypeError(/*L*/"Invalid modes: " + modes);
 
@@ -746,7 +746,7 @@ var Mappings = Module("mappings", {
             names: ["-mode", "-m"],
             type: CommandOption.STRING,
             validator: function (value) {
-                return Array.concat(value).every(findMode);
+                return [].concat(value).every(findMode);
             },
             completer: function () {
                 return modes.all.filter(mode => !mode.hidden)

--- a/common/content/quickmarks.js
+++ b/common/content/quickmarks.js
@@ -106,7 +106,7 @@ var QuickMarks = Module("quickmarks", {
         let uppercaseMarks = marks.filter(bind("test", /[A-Z]/)).sort();
         let numberMarks    = marks.filter(bind("test", /[0-9]/)).sort();
 
-        marks = Array.concat(lowercaseMarks, uppercaseMarks, numberMarks);
+        marks = [].concat(lowercaseMarks, uppercaseMarks, numberMarks);
 
         dactyl.assert(marks.length > 0, _("quickmark.none"));
 

--- a/common/modules/addons.jsm
+++ b/common/modules/addons.jsm
@@ -421,7 +421,7 @@ var Addons = Module("addons", {
                 return (!perm || addon.permissions & perm) && (!command.filter || command.filter(addon));
             }
 
-            commands.add(Array.concat(command.name),
+            commands.add([].concat(command.name),
                 command.description,
                 function (args) {
                     let name = args[0];

--- a/common/modules/base.jsm
+++ b/common/modules/base.jsm
@@ -681,7 +681,7 @@ function isinstance(object, interfaces) {
     if (object == null)
         return false;
 
-    return Array.concat(interfaces).some(function isinstance_some(iface) {
+    return [].concat(interfaces).some(function isinstance_some(iface) {
         if (typeof iface === "string") {
             if (objToString(object) === "[object " + iface + "]")
                 return true;
@@ -1250,7 +1250,7 @@ memoize(Class.prototype, "bound", Class.makeClosure);
  * @returns {Class}
  */
 function XPCOM(interfaces, superClass) {
-    interfaces = Array.concat(interfaces);
+    interfaces = [].concat(interfaces);
 
     let shim = XPCOMShim(interfaces);
 

--- a/common/modules/commands.jsm
+++ b/common/modules/commands.jsm
@@ -134,7 +134,7 @@ update(CommandOption, {
  */
 var Command = Class("Command", {
     init: function init(specs, description, action, extra) {
-        specs = Array.concat(specs); // XXX
+        specs = [].concat(specs); // XXX
 
         this.specs = specs;
         this.description = description;
@@ -992,7 +992,7 @@ var Commands = Module("commands", {
     hasDomain: function hasDomain(command, host) {
         try {
             for (let [cmd, args] of this.subCommands(command))
-                if (Array.concat(cmd.domains(args)).some(domain => util.isSubdomain(domain, host)))
+                if ([].concat(cmd.domains(args)).some(domain => util.isSubdomain(domain, host)))
                     return true;
         }
         catch (e) {

--- a/common/modules/completion.jsm
+++ b/common/modules/completion.jsm
@@ -441,7 +441,7 @@ var CompletionContext = Class("CompletionContext", {
             yield ["context", function p_context() { return self; }];
             yield ["result", quote ? function p_result() { return quote[0] + util.trapErrors(1, quote, this.text) + quote[2]; }
                                    : function p_result() { return this.text; }];
-            yield ["texts", function p_texts() { return Array.concat(this.text); }];
+            yield ["texts", function p_texts() { return [].concat(this.text); }];
         };
 
         for (let i of iter(this.keys, result(this.quote))) {

--- a/common/modules/help.jsm
+++ b/common/modules/help.jsm
@@ -218,7 +218,7 @@ var Help = Module("Help", {
     flush: function flush(entries, time) {
         cache.flushEntry("help.json", time);
 
-        for (let entry of Array.concat(entries || []))
+        for (let entry of [].concat(entries || []))
             cache.flushEntry(entry, time);
     },
 

--- a/common/modules/javascript.jsm
+++ b/common/modules/javascript.jsm
@@ -698,7 +698,7 @@ var JavaScript = Module("javascript", {
      *      functions.
      */
     setCompleter: function (funcs, completers) {
-        funcs = Array.concat(funcs);
+        funcs = [].concat(funcs);
         for (let func of funcs) {
             func.dactylCompleter = function (context, func, obj, args) {
                 let completer = completers[args.length - 1];

--- a/common/modules/options.jsm
+++ b/common/modules/options.jsm
@@ -758,7 +758,7 @@ var Option = Class("Option", {
         },
 
         stringlist: function stringlist(operator, values, scope, invert) {
-            values = Array.concat(values);
+            values = [].concat(values);
 
             function uniq(ary) {
                 let seen = new RealSet;
@@ -767,10 +767,10 @@ var Option = Class("Option", {
 
             switch (operator) {
             case "+":
-                return uniq(Array.concat(this.value, values), true);
+                return uniq([].concat(this.value, values), true);
             case "^":
                 // NOTE: Vim doesn't prepend if there's a match in the current value
-                return uniq(Array.concat(values, this.value), true);
+                return uniq([].concat(values, this.value), true);
             case "-":
                 return this.value.filter(function (item) {
                     return !this.has(item);
@@ -839,9 +839,9 @@ var Option = Class("Option", {
             acceptable = new RealSet(Object.keys(acceptable).map(k => this.parseKey(k)));
 
         if (this.type === "regexpmap" || this.type === "sitemap")
-            return Array.concat(vals).every(re => acceptable.has(re.result));
+            return [].concat(vals).every(re => acceptable.has(re.result));
 
-        return Array.concat(vals).every(v => acceptable.has(v));
+        return [].concat(vals).every(v => acceptable.has(v));
     },
 
     types: {}

--- a/common/modules/overlay.jsm
+++ b/common/modules/overlay.jsm
@@ -245,7 +245,7 @@ var Overlay = Module("Overlay", XPCOM([Ci.nsIObserver, Ci.nsISupportsWeakReferen
         if (url instanceof Ci.nsIDOMWindow)
             overlay._loadOverlay(url, fn);
         else {
-            Array.concat(url).forEach(function (url) {
+            [].concat(url).forEach(function (url) {
                 let matcher = this.matchFilter(url);
                 if (!matcher.exact)
                     this.overlayMatchers.push([matcher, fn]);

--- a/common/modules/services.jsm
+++ b/common/modules/services.jsm
@@ -159,7 +159,7 @@ var Services = Module("Services", {
      */
     add: function add(name, class_, ifaces, meth) {
         const self = this;
-        this.services[name] = { method: meth, class: class_, interfaces: Array.concat(ifaces || []) };
+        this.services[name] = { method: meth, class: class_, interfaces: [].concat(ifaces || []) };
         if (name in this && ifaces && !Object.getOwnPropertyDescriptor(this, name).get && !(this[name] instanceof Ci.nsISupports))
             throw TypeError();
         memoize(this, name, () => self._create(name));
@@ -177,7 +177,7 @@ var Services = Module("Services", {
      */
     addClass: function addClass(name, class_, ifaces, init = null, quiet = true) {
         this.services[name] = { class: class_,
-                                interfaces: Array.concat(ifaces || []),
+                                interfaces: [].concat(ifaces || []),
                                 method: "createInstance",
                                 init: init,
                                 quiet: quiet };
@@ -190,7 +190,7 @@ var Services = Module("Services", {
         this[name] = (...args) => this._create(name, args);
 
         update(this[name],
-               ...Array.concat(ifaces).map(iface => Ci[iface]));
+               ...[].concat(ifaces).map(iface => Ci[iface]));
 
         return this[name];
     },

--- a/common/modules/template.jsm
+++ b/common/modules/template.jsm
@@ -385,7 +385,7 @@ var Template = Module("Template", {
             _i = i;
 
             s.push(str.substring(start, i),
-                   highlight.apply(this, Array.concat(args || str.substr(i, length))));
+                   highlight.apply(this, [].concat(args || str.substr(i, length))));
             start = i + length;
         }
         s.push(str.substr(start));

--- a/common/tests/functional/testCommands.js
+++ b/common/tests/functional/testCommands.js
@@ -676,7 +676,7 @@ var tests = {
             ["! " + name, sidebarState(false)]
         ],
         get noOutput()
-            Array.concat.apply([],
+            [].concat.apply([],
                 ["Add-ons", // Final "! Add-ons" currently failing
                  "Bookmarks",
                  "Downloads",
@@ -953,7 +953,7 @@ function addTest(cmdName, testName, func) {
 function runCommands(cmdName, testName, commands, test, forbidErrors) {
     addTest(cmdName, testName, function () {
         commands.forEach(function (val) {
-            var [cmd, testVal] = Array.concat(val);
+            var [cmd, testVal] = [].concat(val);
 
             dump("CMD: " + testName + " " + cmdName + " " + cmd + "\n");
             dactyl.clearMessage();
@@ -974,7 +974,7 @@ function runCommands(cmdName, testName, commands, test, forbidErrors) {
 function _runCommands(cmdName, testName, commands) {
     addTest(cmdName, testName, function () {
         commands.forEach(function (value) {
-            var [cmd, test] = Array.concat(value);
+            var [cmd, test] = [].concat(value);
 
             dump("CMD: " + testName + " " + cmdName + " " + cmd + "\n");
             var res = dactyl.runExCommand(cmd);
@@ -993,7 +993,7 @@ function runTest(message, test, ...args) {
 }
 
 for (var val in Iterator(tests)) (function ([command, paramsList]) {
-    Array.concat(paramsList).forEach(function (params, i) {
+    [].concat(paramsList).forEach(function (params, i) {
         if (params.init)
             _runCommands(command, "init" + (i || ""), params.init);
 
@@ -1039,7 +1039,7 @@ for (var val in Iterator(tests)) (function ([command, paramsList]) {
             case "error":
                 addTest(command, testName, function () {
                     commands.forEach(function (val) {
-                        var [cmd, test] = Array.concat(val);
+                        var [cmd, test] = [].concat(val);
                         cmd = command + cmd.replace(/^(!?) ?/, "$1 ");
 
                         var res = dactyl.assertMessageError(function () {
@@ -1055,7 +1055,7 @@ for (var val in Iterator(tests)) (function ([command, paramsList]) {
             case "completions":
                 addTest(command, testName, function () {
                     commands.forEach(function (val) {
-                        var [cmd, test] = Array.concat(val);
+                        var [cmd, test] = [].concat(val);
                         cmd = command + cmd.replace(/^(!?) ?/, "$1 ");
 
                         dactyl.assertNoErrorMessages(function () {

--- a/plugins/noscript.js
+++ b/plugins/noscript.js
@@ -28,7 +28,7 @@ function getSites() {
     const blockUntrusted = global && ns.alwaysBlockUntrustedContent;
 
     let res = [];
-    for (let site of array.iterValues(Array.concat(sites.topSite, sites))) {
+    for (let site of array.iterValues([].concat(sites.topSite, sites))) {
         let ary = [];
 
         let untrusted    = groups.untrusted.matches(site);
@@ -311,7 +311,7 @@ group.options.add(["script"],
         names: ["noscript-objects", "nso"],
         description: "The list of allowed objects",
         get set() { return new RealSet(array.flatten(
-            [Array.concat(v).map(function (v) { return v + "@" + this; }, k)
+            [[].concat(v).map(function (v) { return v + "@" + this; }, k)
              for ([k, v] of iter(services.noscript.objectWhitelist))])) },
         action: function (add, patterns) {
             for (let pattern of values(patterns)) {


### PR DESCRIPTION
It appears that Array.concat('foo') gives an array with a String object
instead of a primitive string value, and this breaks things. (I have no
idea why Array.concat even worked at all in the first place; it
definitely fails in Chrome, for example. Only Array.prototype.concat
seems to exist.)

Fixes setting the defsearch option.
